### PR TITLE
manifest: Remove external/libvorbis

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -216,7 +216,6 @@
   <project path="external/libusb" name="platform/external/libusb" groups="pdk" remote="aosp" />
   <project path="external/libusb-compat" name="platform/external/libusb-compat" groups="pdk" remote="aosp" />
   <project path="external/libvncserver" name="platform/external/libvncserver" groups="pdk" remote="aosp" />
-  <project path="external/libvorbis" name="LineageOS/android_external_libvorbis" groups="pdk" />
   <project path="external/libvpx" name="platform/external/libvpx" groups="pdk" remote="aosp" />
   <project path="external/libvterm" name="platform/external/libvterm" groups="pdk" remote="aosp" />
   <project path="external/libxml2" name="platform/external/libxml2" groups="pdk,libxml2" remote="aosp" />


### PR DESCRIPTION
* Removed by Google in android-8.1.0_r30

Change-Id: I033aa88fc0ecc899b1a1c1feecc4a7aab5d76441